### PR TITLE
Support MySQL 8.0 debug build container image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: bash
 services: docker
 
 env:
+  - VERSION=8.0
   - VERSION=5.7
   - VERSION=5.6
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty as builder
 
-ARG MYSQL_VERSION=5.6.38
+ARG MYSQL_VERSION=5.6.40
 
 WORKDIR /root
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty as builder
 
-ARG MYSQL_VERSION=5.7.20
+ARG MYSQL_VERSION=5.7.22
 
 WORKDIR /root
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:trusty as builder
+
+ARG MYSQL_VERSION=8.0.11
+
+WORKDIR /root
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install build-essential cmake wget curl libncurses5-dev libssl-dev -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' && \
+    wget http://ftp.jaist.ac.jp/pub/mysql/Downloads/MySQL-8.0/mysql-boost-${MYSQL_VERSION}.tar.gz && \
+    tar zxf mysql-boost-${MYSQL_VERSION}.tar.gz && \
+    cd mysql-${MYSQL_VERSION} && \
+    CFLAGS=-O0 cmake -DWITH_DEBUG=1 -DWITH_INNODB_EXTRA_DEBUG=1 -DCMAKE_INSTALL_PREFIX=/mysql-debug -DDOWNLOAD_BOOST=1 -DWITH_BOOST=./boost && \
+    make -j$(getconf _NPROCESSORS_ONLN) install && \
+    cd .. && \
+    rm -rf mysql-${MYSQL_VERSION}
+
+WORKDIR /mysql-debug
+RUN ./bin/mysqld  --no-defaults --datadir=./data --basedir=./ --initialize-insecure
+
+FROM ubuntu:trusty
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install gdb gdbserver -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' && \
+    echo '[mysqld]\nskip-host-cache\nskip-name-resolve\nskip-grant-tables' > /etc/my.cnf && \
+    rm /etc/sysctl.d/10-ptrace.conf && \
+    sysctl -p
+
+COPY --from=builder /mysql-debug /mysql-debug
+EXPOSE 3306
+EXPOSE 2345
+CMD cd /mysql-debug; sudo gdbserver :2345 ./bin/mysqld --user=root --skip-grant-tables --datadir=./data --basedir=./ --user=root

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This Dockerfile builds MySQL database server with debugging information.
 
 ### How to Build ###
 
+#### MySQL 8.0 ####
+
+```
+$ docker build -t mysql-debug-8.0 8.0
+```
+
 #### MySQL 5.7 ####
 
 ```


### PR DESCRIPTION
MySQL 8.0 GA is now available. This change supports MySQL 8.0 debug build container image.

Note:
* libssl-dev is required for MySQL 8.0 build
* WITH_PIC option of configure script is removed.
